### PR TITLE
- added support for delete All, update Attributes, Non numeric ID attribute of node and match all that supports IN type query

### DIFF
--- a/lib/neo4j.js
+++ b/lib/neo4j.js
@@ -32,35 +32,46 @@ neo4j.create = function (model, data, cb) {
 }
 
 neo4j.save = function (model, data, cb) {
-    console.log('save...');
     cb();
 }
 
 neo4j.all = function (model, filter, cb) {
     var keys = Object.keys(filter);
+   
     var keyToSymbol = function (key) {
         return key + ':{filter}.' + key;
     }
-    var f = keys
-        .reduce(function (out, k, i) {
-            var symbol = keyToSymbol(k);
-            if (keys.length === 0) {
-                out = '';
-            } else if (keys.length === 1) {
-                out = '{ ' + symbol + '}';
-            } else if (i === 0) {
-                out = '{ ' + symbol;
-            } else if (i === keys.length-1) {
-                out = out + ',' + symbol;
-            } else {
-                out = out + ',' + symbol + '}';
+   
+    // Build filter which supports IN query
+    var newfilter = "";
+    if(filter){
+        var item;
+        if(filter.where)
+            item = filter.where;
+        else
+            item = filter;
+      
+        // Build new filter
+        for (var property in item) {
+            if (item.hasOwnProperty(property)) {
+                if(newfilter.length>0) newfilter +=" AND "
+                    else newfilter = "where "
+                if(item[property].inq){
+                    newfilter += 'n.' + property + ' IN ' + JSON.stringify(item[property].inq);
+                }else{
+                    newfilter += 'n.' + property + ' = ' + JSON.stringify(item[property]);
+                }
             }
-            return out;
-        }, '');
+        }
+    }
+ 
 
-    var query = ('match (n:%node% ' + f + ') return n')
-        .replace('%node%', model);
-    var params = { filter: filter };
+    var query = ('match (n:%node%) %filter% return n')
+        .replace('%node%', model)
+    query = query.replace('%filter%', newfilter);
+ 
+    // Passing filter in the query itself without parameters
+    var params = {};
 
     this.db.query(query, params, function (err, results) {
         if (err) return cb(err);
@@ -69,6 +80,7 @@ neo4j.all = function (model, filter, cb) {
         }));
     });
 }
+
 
 neo4j.find = function (model, id, cb) {
     this.db.getNodeById(id, function (err, node) {
@@ -83,9 +95,18 @@ neo4j.exists = function (model, id, cb) {
 }
 
 neo4j.destroy = function (model, id, cb) {
-    var query = 'match (n:%node%) where ID(n) = {id} delete n'
+    console.log('in delete');
+    var query = 'match (n:%node%) where (n.id) = {id} delete n'
         .replace('%node%', model);
     var params = { id: Number(id) };
+    this.db.query(query, params, cb);
+}
+
+ neo4j.destroyAll = function(model, where, cb) {
+    console.log('in deleteAll');
+    var query = 'match (n:%node%) where (n.id) = {id} delete n'
+        .replace('%node%', model);
+    var params = where;
     this.db.query(query, params, cb);
 }
 
@@ -95,6 +116,28 @@ neo4j.count = function (model, cb, where) {
 };
 
 neo4j.updateAttributes = function (model, id, data, cb) {
-    console.log('updateAttributes', id, data)
-    cb();
+    console.log('updateAttributes', id, model);
+    var payload = '';
+
+    for (var property in data) {
+        if (data.hasOwnProperty(property)) {
+            if(payload.length>0) 
+                payload +=" , ";
+            else
+                payload = "{";
+           
+            payload += property + ' : ' + JSON.stringify(data[property]);
+        }
+    }
+    payload += "}";
+
+
+     var query = 'match (n:%node%)  where (n.id) = {id} set n=' + payload ;
+     query = query.replace('%node%', model);
+    console.log('Finaly query is : ' + query);
+
+    var params = { id: data.id };
+    this.db.query(query, params, cb);
+
+   // cb();
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "haio",
+  "author": {
+    "name": "haio"
+  },
   "license": "MIT",
   "dependencies": {
     "neo4j": "~1.1.0"
@@ -14,5 +16,29 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:IndustrialCloudSolutions/loopback-connector-neo4j.git"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/IndustrialCloudSolutions/loopback-connector-neo4j/issues"
+  },
+  "homepage": "https://github.com/IndustrialCloudSolutions/loopback-connector-neo4j",
+  "_id": "loopback-connector-neo4j@0.1.3",
+  "dist": {
+    "shasum": "ae0fa1f2b46e36c5a73bf6caf5f9624c3e366d13",
+    "tarball": "http://registry.npmjs.org/loopback-connector-neo4j/-/loopback-connector-neo4j-0.1.3.tgz"
+  },
+  "_from": "loopback-connector-neo4j@*",
+  "_npmVersion": "1.3.24",
+  "_npmUser": {
+    "name": "haio",
+    "email": "mockingror@gmail.com"
+  },
+  "maintainers": [
+    {
+      "name": "haio",
+      "email": "mockingror@gmail.com"
+    }
+  ],
+  "directories": {},
+  "_shasum": "ae0fa1f2b46e36c5a73bf6caf5f9624c3e366d13",
+  "_resolved": "https://registry.npmjs.org/loopback-connector-neo4j/-/loopback-connector-neo4j-0.1.3.tgz"
 }


### PR DESCRIPTION
The existing code was attempting to treat all IDs as integers, in case of any string like GUID, it'd simply not work. So this version has support non numeric IDs

Match All, had a function passing filter data as parameter, so when sending a list of IDs in an array to search, it'd attempt to search inq:[array] which would produce no results. So had to re-write the search query for IN to function. 

Updating attributes wasn't fully implemented and same for deleteAll which gets called occasionally even if you aren't deleting multiple items. This version includes support for those 2. 
